### PR TITLE
Removed unnecessary clones in rug trial_division

### DIFF
--- a/src/factoring/trial_division.rs
+++ b/src/factoring/trial_division.rs
@@ -94,6 +94,7 @@ impl TrialDivision for rug::Integer {
             for delta in TEST_DELTA {
                 f.assign(&current_factor + delta);
                 while self.is_divisible(&f){
+                    self /= &f;
                     result.push(f.clone());
                     changed = true;
                 }

--- a/src/factoring/trial_division.rs
+++ b/src/factoring/trial_division.rs
@@ -76,17 +76,12 @@ prim_trial_division!(u128);
 impl TrialDivision for rug::Integer {
     fn trial_division(mut self, inclusive_bound: &Self) -> (Vec<Self>, bool) {
         use rug::Assign;
-        const PRE_PRIMES: [u8; 3] = [2u8, 3, 5];
-        const TEST_DELTA: [u8; 2] = [1, 5];
-        const ROUND_INCREMENT: u8 = 6;
+        const PRE_PRIMES: [u32; 3] = [2, 3, 5];
+        const TEST_DELTA: [u32; 2] = [1, 5];
+        const ROUND_INCREMENT: u32 = 6;
         let mut result = vec![];
-        let mut tmp = Self::new();
         for prime in PRE_PRIMES {
-            loop{
-                tmp.assign(&self % prime);
-                if tmp != 0 {
-                    break
-                }
+            while self.is_divisible_u(prime){
                 result.push(prime.into());
                 self /= prime;
             }
@@ -98,11 +93,7 @@ impl TrialDivision for rug::Integer {
             let mut changed = false;
             for delta in TEST_DELTA {
                 f.assign(&current_factor + delta);
-                loop{
-                    tmp.assign(&self % &f);
-                    if tmp != 0 {
-                        break
-                    }
+                while self.is_divisible(&f){
                     result.push(f.clone());
                     changed = true;
                 }


### PR DESCRIPTION
Reusing storage and reducing allocations by `.assign()`ing incomplete operation results to variables instead of `.clone()`ing. On my machine it's ~6x faster (tested by factoring a product of 20 random primes <100_000_000).

I also had a glance at the rest of the code, and similar optimizations could improve other functions using rug (but they are best modified by someone more familiar with the code).

Also I'm not quite sure why this function consumes `self` instead of taking `&self` and `clone`ing it. Factorisation operation doesn't feel like it requires ownership of the number it factors.